### PR TITLE
fix: Add '--parseDependency' to solve swag generator error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 swag:
 	swag fmt
 	swag init -g internal/routers/api_v1.go --ot json -o api --instanceName api_v1 \
-		--exclude website,api,bin,build,deployment -q
+		--exclude website,api,bin,build,deployment --parseDependency -q
 	openapi-generator-cli generate -i /local/api/api_v1_swagger.json -g typescript-axios -o /local/website/src/api
 
 .PHONY: build

--- a/api/api_v1_swagger.json
+++ b/api/api_v1_swagger.json
@@ -7,9 +7,9 @@
     },
     "basePath": "/api/v1",
     "paths": {
-        "/user": {
-            "post": {
-                "description": "Create a new user with the provided details",
+        "/api/v1/user/me": {
+            "get": {
+                "description": "Retrieve the information of the currently authenticated user",
                 "consumes": [
                     "application/json"
                 ],
@@ -17,15 +17,88 @@
                     "application/json"
                 ],
                 "tags": [
-                    "User"
+                    "user"
                 ],
-                "summary": "Create a new user",
+                "summary": "Get current user",
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/userpb.User"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/echo.HTTPError"
+                        }
                     }
                 }
             }
+        }
+    },
+    "definitions": {
+        "echo.HTTPError": {
+            "type": "object",
+            "properties": {
+                "message": {}
+            }
+        },
+        "timestamppb.Timestamp": {
+            "type": "object",
+            "properties": {
+                "nanos": {
+                    "description": "Non-negative fractions of a second at nanosecond resolution. Negative\nsecond values with fractions must still have non-negative nanos values\nthat count forward in time. Must be from 0 to 999,999,999\ninclusive.",
+                    "type": "integer"
+                },
+                "seconds": {
+                    "description": "Represents seconds of UTC time since Unix epoch\n1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to\n9999-12-31T23:59:59Z inclusive.",
+                    "type": "integer"
+                }
+            }
+        },
+        "userpb.User": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "$ref": "#/definitions/timestamppb.Timestamp"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "github_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/userpb.UserRole"
+                },
+                "updated_at": {
+                    "$ref": "#/definitions/timestamppb.Timestamp"
+                }
+            }
+        },
+        "userpb.UserRole": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "UserRole_USER",
+                "UserRole_ADMIN"
+            ]
         }
     }
 }

--- a/website/src/api/.openapi-generator/FILES
+++ b/website/src/api/.openapi-generator/FILES
@@ -4,6 +4,10 @@ api.ts
 base.ts
 common.ts
 configuration.ts
+docs/EchoHTTPError.md
+docs/TimestamppbTimestamp.md
 docs/UserApi.md
+docs/UserpbUser.md
+docs/UserpbUserRole.md
 git_push.sh
 index.ts

--- a/website/src/api/api.ts
+++ b/website/src/api/api.ts
@@ -23,6 +23,103 @@ import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';
 
+/**
+ * 
+ * @export
+ * @interface EchoHTTPError
+ */
+export interface EchoHTTPError {
+    /**
+     * 
+     * @type {object}
+     * @memberof EchoHTTPError
+     */
+    'message'?: object;
+}
+/**
+ * 
+ * @export
+ * @interface TimestamppbTimestamp
+ */
+export interface TimestamppbTimestamp {
+    /**
+     * Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive.
+     * @type {number}
+     * @memberof TimestamppbTimestamp
+     */
+    'nanos'?: number;
+    /**
+     * Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.
+     * @type {number}
+     * @memberof TimestamppbTimestamp
+     */
+    'seconds'?: number;
+}
+/**
+ * 
+ * @export
+ * @interface UserpbUser
+ */
+export interface UserpbUser {
+    /**
+     * 
+     * @type {TimestamppbTimestamp}
+     * @memberof UserpbUser
+     */
+    'created_at'?: TimestamppbTimestamp;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserpbUser
+     */
+    'email'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserpbUser
+     */
+    'github_id'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof UserpbUser
+     */
+    'id'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof UserpbUser
+     */
+    'name'?: string;
+    /**
+     * 
+     * @type {UserpbUserRole}
+     * @memberof UserpbUser
+     */
+    'role'?: UserpbUserRole;
+    /**
+     * 
+     * @type {TimestamppbTimestamp}
+     * @memberof UserpbUser
+     */
+    'updated_at'?: TimestamppbTimestamp;
+}
+
+
+/**
+ * 
+ * @export
+ * @enum {number}
+ */
+
+export const UserpbUserRole = {
+    UserRole_USER: 0,
+    UserRole_ADMIN: 1
+} as const;
+
+export type UserpbUserRole = typeof UserpbUserRole[keyof typeof UserpbUserRole];
+
+
 
 /**
  * UserApi - axios parameter creator
@@ -31,13 +128,13 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerM
 export const UserApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
-         * Create a new user with the provided details
-         * @summary Create a new user
+         * Retrieve the information of the currently authenticated user
+         * @summary Get current user
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        userPost: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/user`;
+        apiV1UserMeGet: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/user/me`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -45,7 +142,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -71,15 +168,15 @@ export const UserApiFp = function(configuration?: Configuration) {
     const localVarAxiosParamCreator = UserApiAxiosParamCreator(configuration)
     return {
         /**
-         * Create a new user with the provided details
-         * @summary Create a new user
+         * Retrieve the information of the currently authenticated user
+         * @summary Get current user
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async userPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.userPost(options);
+        async apiV1UserMeGet(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserpbUser>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1UserMeGet(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['UserApi.userPost']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['UserApi.apiV1UserMeGet']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
     }
@@ -93,13 +190,13 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
     const localVarFp = UserApiFp(configuration)
     return {
         /**
-         * Create a new user with the provided details
-         * @summary Create a new user
+         * Retrieve the information of the currently authenticated user
+         * @summary Get current user
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        userPost(options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.userPost(options).then((request) => request(axios, basePath));
+        apiV1UserMeGet(options?: RawAxiosRequestConfig): AxiosPromise<UserpbUser> {
+            return localVarFp.apiV1UserMeGet(options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -112,14 +209,14 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
  */
 export class UserApi extends BaseAPI {
     /**
-     * Create a new user with the provided details
-     * @summary Create a new user
+     * Retrieve the information of the currently authenticated user
+     * @summary Get current user
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof UserApi
      */
-    public userPost(options?: RawAxiosRequestConfig) {
-        return UserApiFp(this.configuration).userPost(options).then((request) => request(this.axios, this.basePath));
+    public apiV1UserMeGet(options?: RawAxiosRequestConfig) {
+        return UserApiFp(this.configuration).apiV1UserMeGet(options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/website/src/api/docs/EchoHTTPError.md
+++ b/website/src/api/docs/EchoHTTPError.md
@@ -1,0 +1,20 @@
+# EchoHTTPError
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**message** | **object** |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { EchoHTTPError } from './api';
+
+const instance: EchoHTTPError = {
+    message,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/website/src/api/docs/TimestamppbTimestamp.md
+++ b/website/src/api/docs/TimestamppbTimestamp.md
@@ -1,0 +1,22 @@
+# TimestamppbTimestamp
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nanos** | **number** | Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. | [optional] [default to undefined]
+**seconds** | **number** | Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive. | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { TimestamppbTimestamp } from './api';
+
+const instance: TimestamppbTimestamp = {
+    nanos,
+    seconds,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/website/src/api/docs/UserApi.md
+++ b/website/src/api/docs/UserApi.md
@@ -4,12 +4,12 @@ All URIs are relative to */api/v1*
 
 |Method | HTTP request | Description|
 |------------- | ------------- | -------------|
-|[**userPost**](#userpost) | **POST** /user | Create a new user|
+|[**apiV1UserMeGet**](#apiv1usermeget) | **GET** /api/v1/user/me | Get current user|
 
-# **userPost**
-> userPost()
+# **apiV1UserMeGet**
+> UserpbUser apiV1UserMeGet()
 
-Create a new user with the provided details
+Retrieve the information of the currently authenticated user
 
 ### Example
 
@@ -22,7 +22,7 @@ import {
 const configuration = new Configuration();
 const apiInstance = new UserApi(configuration);
 
-const { status, data } = await apiInstance.userPost();
+const { status, data } = await apiInstance.apiV1UserMeGet();
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ This endpoint does not have any parameters.
 
 ### Return type
 
-void (empty response body)
+**UserpbUser**
 
 ### Authorization
 
@@ -40,13 +40,15 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: application/json
 
 
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 |**200** | OK |  -  |
+|**401** | Unauthorized |  -  |
+|**500** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/website/src/api/docs/UserpbUser.md
+++ b/website/src/api/docs/UserpbUser.md
@@ -1,0 +1,32 @@
+# UserpbUser
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**created_at** | [**TimestamppbTimestamp**](TimestamppbTimestamp.md) |  | [optional] [default to undefined]
+**email** | **string** |  | [optional] [default to undefined]
+**github_id** | **string** |  | [optional] [default to undefined]
+**id** | **number** |  | [optional] [default to undefined]
+**name** | **string** |  | [optional] [default to undefined]
+**role** | [**UserpbUserRole**](UserpbUserRole.md) |  | [optional] [default to undefined]
+**updated_at** | [**TimestamppbTimestamp**](TimestamppbTimestamp.md) |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { UserpbUser } from './api';
+
+const instance: UserpbUser = {
+    created_at,
+    email,
+    github_id,
+    id,
+    name,
+    role,
+    updated_at,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)


### PR DESCRIPTION
## Description

This PR fixes the swag generation error by adding the `--parseDependency` flag to the swag command in the Makefile.

## Problem

The `make swag` command error
## Solution

Added the `--parseDependency` flag to the swag command in the Makefile to enable parsing of Go files in dependency packages.

## Related Issue
- #7 
